### PR TITLE
Fix small typo in onboarding view

### DIFF
--- a/Tuneful/Views/OnboardingView.swift
+++ b/Tuneful/Views/OnboardingView.swift
@@ -37,7 +37,7 @@ struct OnboardingView: View {
                                 .font(.title2)
                                 .fontWeight(.semibold)
                         } else if step == .onDetails {
-                            Text("2. Permssions")
+                            Text("2. Permissions")
                                 .font(.title2)
                                 .fontWeight(.semibold)
                         } else if step == .onShortcuts {


### PR DESCRIPTION
Notice when I first opened

<img width="612" alt="Screenshot 2024-10-15 at 15 41 34" src="https://github.com/user-attachments/assets/e885c8b8-d807-4b85-a439-829caefabd57">
