### PR TITLE
Update release.yml to only trigger on main branch updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: "Create Release"
 on:
-    issue_comment:
-        types: [created]
+  push:
+    branches:
+      - main
 
 concurrency:
     group: publish-release${{ github.ref }}


### PR DESCRIPTION
Every comment on issues, even by non-contributors, trigger the Create Release workflow. The workflow fails silently since the conditions are not met, but the commenter receives a Run Failed mail from GitHub, oblivious to what's going on.

This change proposes changing the trigger condition for the workflow.