### PR TITLE
Fixed a crash after clicking settings on MacBook without a notch

### DIFF
--- a/Tuneful/Tuneful.swift
+++ b/Tuneful/Tuneful.swift
@@ -94,11 +94,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let paneView = Settings.Pane(
             identifier: .notch,
             title: "Notch",
-            toolbarIcon: NSImage(systemSymbolName: "button.roundedbottom.horizontal", accessibilityDescription: "Notch settings")!
-        ) {
-            NotchSettingsView()
-        }
-        
+            toolbarIcon: {
+                NSImage(systemSymbolName: "button.roundedbottom.horizontal", accessibilityDescription: "Notch settings") 
+                ?? NSImage(named: NSImage.actionTemplateName) ?? NSImage()
+            }(),
+            contentView: { NotchSettingsView() }
+        )
+    
         return Settings.PaneHostingController(pane: paneView)
     }
     


### PR DESCRIPTION
Fixed a crash in NotchSettingsViewController that occurred on Macs without a notch by ensuring NSImage(systemSymbolName:) only initializes when the symbol exists.

Somewhat related:
I had to replace the "import SwiftUICore" imports in three files with "import SwiftUI" since SwiftUICore is not included in the repo. Feel free to test that on new devices as well.